### PR TITLE
メイン武器の間違っているデータを修正

### DIFF
--- a/src/resources/main.yaml
+++ b/src/resources/main.yaml
@@ -974,7 +974,7 @@
       safety: true
       
 - name: アクセルミサイルガン
-  no: 71473
+  no: 71472
   rank: ルーキー
   recipe:
     - item: GLスフィア
@@ -1068,7 +1068,7 @@
     - item: 暗いGRスフィア
       required: 10
       safety: true
-    - item: 暗いGRスフィア
+    - item: 暗いパラレルコア
       required: 15
       safety: true
     - item: アマムカの弾丸


### PR DESCRIPTION
## 概要
#18 の原因となっている間違っているデータの修正

<!-- このPull Requestで変更される変更点 -->
- No. 71472のアイテムIDが被っていたので修正
- No. 71475のレシピが間違っていたので修正

close #18 