### PR TITLE
検索条件変更時に展開したレシピを閉じるように変更

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -63,6 +63,7 @@ export default class App extends React.Component<Props, State> {
 
     changeFilter(data: DropdownProps) {
         this.setState({
+            open: -1,
             filter: data.value as filter
         }, () => {
             this.searchRecipes()
@@ -71,6 +72,7 @@ export default class App extends React.Component<Props, State> {
 
     changeKeyword(data: InputOnChangeData) {
         this.setState({
+            open: -1,
             keyword: data.value
         }, () => {
             this.searchRecipes()


### PR DESCRIPTION
## 概要
#20 の修正
Close #20 

<!-- このPull Requestで変更される変更点 -->
- 検索条件変更時に展開中のアイテムIDの値を初期化するように変更

## 備考
展開アイテムをindex値としているがレシピNoがユニークなデータなのでこっちにした方が利便性良さそう（検索条件を変更しても当該アイテムがあれば展開された状態を維持できるため）
