### PR TITLE
ページを戻った際に検索されないバグを修正

### DIFF
--- a/src/routes/indexPage.tsx
+++ b/src/routes/indexPage.tsx
@@ -67,6 +67,14 @@ export default class IndexPage extends React.Component<Props, State> {
         }
     }
 
+    componentWillReceiveProps(nextProps: Props) {
+        const query = queryString.parse(nextProps.location.search) as {filter: filter, keyword: string}
+        this.setState({
+            filter: this.filter.some((item) => item.value === query.filter)? query.filter : 'all',
+            keyword: query.keyword || '',
+        })
+    }
+
     handleClick(event: React.MouseEvent, accordion: AccordionTitleProps) {
         const index = parseInt(accordion.index!.toString())
         this.setState({
@@ -87,8 +95,6 @@ export default class IndexPage extends React.Component<Props, State> {
         this.setState({
             open: -1,
             keyword: data.value
-        }, () => {
-            this.props.history.push(`?filter=${this.state.filter}&keyword=${this.state.keyword}`)
         })
     }
 
@@ -131,6 +137,12 @@ export default class IndexPage extends React.Component<Props, State> {
                             placeholder='レシピ名/No/素材名'
                             value={this.state.keyword}
                             onChange={(e, d) => this.changeKeyword(d)}
+                            onBlur={() => {
+                                const query = `?filter=${this.state.filter}&keyword=${this.state.keyword}`
+                                if (query !== this.props.location.search) {
+                                    this.props.history.push(`?filter=${this.state.filter}&keyword=${this.state.keyword}`)
+                                }
+                            }}
                             icon='search'
                             iconPosition='left'
                             action={

--- a/src/routes/indexPage.tsx
+++ b/src/routes/indexPage.tsx
@@ -65,6 +65,7 @@ export default class IndexPage extends React.Component<Props, State> {
             filter: this.filter.some((item) => item.value === query.filter)? query.filter : 'all',
             keyword: query.keyword || '',
         }
+        document.title = `C21 Laboratory Recipes | ${this.state.keyword}`
     }
 
     componentWillReceiveProps(nextProps: Props) {
@@ -141,6 +142,7 @@ export default class IndexPage extends React.Component<Props, State> {
                                 const query = `?filter=${this.state.filter}&keyword=${this.state.keyword}`
                                 if (query !== this.props.location.search) {
                                     this.props.history.push(`?filter=${this.state.filter}&keyword=${this.state.keyword}`)
+                                    document.title = `C21 Laboratory Recipes | ${this.state.keyword}`
                                 }
                             }}
                             icon='search'


### PR DESCRIPTION
## 概要
- #36 のメイン修正
  - ページ遷移時にstateを再設定するように
- サブ修正（履歴がエグいことになる件）
  - 検索条件の保存をInputのフォーカスを外れた時に変更し、差分がある場合のみ更新するように
  - onChangeの検索条件の保存処理を削除
